### PR TITLE
Display article when no JS

### DIFF
--- a/server-templates/article-shell.dust
+++ b/server-templates/article-shell.dust
@@ -12,15 +12,17 @@
       {/flags.article-css-import}
       <div class="article-container">
     {:else}
-      <div class="article-container" style="display:none">
+      <div class="article-container">
         <script>{`
           (function() {
+            var article = document.querySelector('.article-container');
             var req = new XMLHttpRequest();
+            article.style.display = 'none';
             req.onload = function() {
               var style = document.createElement('style');
               style.textContent = req.responseText;
               document.head.appendChild(style);
-              document.querySelector('.article-container').style.display = '';
+              article.style.display = '';
             }
             req.open('GET', '/css/wiki.css');
             req.send();


### PR DESCRIPTION
When the script below `<div class="article-container" style="display:none">`isn't executed,
the article remains invisible even though it has content. This change fixes this as it
hides the element using JS, just before the XHR request. Other behaviour remains unchanged.

(now `querySelector` is the feature detection for both hiding and showing the content)
